### PR TITLE
Install GitHub CLI to devcontainer

### DIFF
--- a/.devcontainer/commands/initializeCommand.sh
+++ b/.devcontainer/commands/initializeCommand.sh
@@ -6,3 +6,17 @@ GO_VERSION=$(grep -m1 '^go ' ./go.mod | awk '{print $2}')
 # DockerfileのARG GO_VERSION行を書き換え
 sed -i "s/^ARG GO_VERSION=.*$/ARG GO_VERSION=${GO_VERSION}/" ./.devcontainer/Dockerfile
 echo "Updated Dockerfile with Go version ${GO_VERSION}"
+
+# GitHub CLI用の認証情報を取得
+if which gh &> /dev/null; then
+    GH_TOKEN=$(gh auth token)
+    if [ -z "$GH_TOKEN" ]; then
+        echo "Skip authentication because gh auth token is empty."
+        [ -f ./.devcontainer/.env.devcontainer ] && rm ./.devcontainer/.env.devcontainer || true
+    else
+        echo "GH_TOKEN=${GH_TOKEN}" > ./.devcontainer/.env.devcontainer
+    fi
+else
+    echo "GitHub CLI is not installed. Skipping authentication."
+    [ -f ./.devcontainer/.env.devcontainer ] && rm ./.devcontainer/.env.devcontainer || true
+fi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,10 @@
 			"USERNAME": "vscode"
 		}
 	},
+	"runArgs": [
+		"--env-file",
+		".devcontainer/.env.devcontainer"
+	],
 	"containerEnv": {},
 	"initializeCommand": "./.devcontainer/commands/initializeCommand.sh",
 	"postCreateCommand": "./.devcontainer/commands/postCreateCommand.sh vscode",
@@ -17,5 +21,8 @@
 	],
 	"workspaceMount": "source=${localWorkspaceFolder},target=/rev-callgraph,type=bind,consistency=cached",
 	"workspaceFolder": "/rev-callgraph",
-	"remoteUser": "vscode"
+	"remoteUser": "vscode",
+	"features": {
+		"ghcr.io/devcontainers/features/github-cli:1": {}
+	}
 }

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ go.work.sum
 # env file
 .env
 
+.devcontainer/.env.devcontainer
 .devcontainer/resources/ignores/*
 !.devcontainer/resources/ignores/.git-keep
 .devcontainer/tmp/**


### PR DESCRIPTION
- GitHub CLI( `gh` ) のインストール
- ホストのgithub CLIのトークンをdevcontainerに伝搬させた