### PR TITLE
chore(renovate): exclude testdata directory from Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "ignorePaths": [
+    "**/testdata/**"
   ]
 }


### PR DESCRIPTION
Add "**/testdata/**" to ignorePaths to prevent Renovate from updating dependencies under testdata. This avoids unnecessary updates for test fixtures and sample code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Renovateの設定を更新し、`**/testdata/**` パターンに一致するファイルやディレクトリを自動更新の対象外としました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->