### PR TITLE
Fix: apply context cancellation support and tests (refs #32)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,12 @@ go 1.24.4
 require (
 	github.com/fatih/color v1.18.0
 	github.com/spf13/cobra v1.9.1
+	github.com/stretchr/testify v1.10.0
 	golang.org/x/mod v0.24.0
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.0 // indirect
@@ -19,6 +21,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
@@ -31,6 +34,7 @@ require (
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 tool (

--- a/go.sum
+++ b/go.sum
@@ -347,8 +347,9 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/internal/astquery/astquery.go
+++ b/internal/astquery/astquery.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/meian/rev-callgraph/internal/contextutil"
 	"github.com/meian/rev-callgraph/internal/gomod"
 	"github.com/meian/rev-callgraph/internal/progress"
 	"github.com/meian/rev-callgraph/internal/symbol"
@@ -45,6 +46,9 @@ func ExtractCallers(ctx context.Context, target string, files []string, modules 
 	progress.Msgf(ctx, "extract callers for %s", target)
 	var callers []symbol.Function
 	for _, file := range files {
+		if contextutil.IsCanceledOrTimedOut(ctx) {
+			return nil, ctx.Err()
+		}
 		// ファイルパース
 		fset := token.NewFileSet()
 		node, err := parser.ParseFile(fset, file, nil, parser.ParseComments)

--- a/internal/astquery/astquery_test.go
+++ b/internal/astquery/astquery_test.go
@@ -1,0 +1,83 @@
+package astquery
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/meian/rev-callgraph/internal/gomod"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractCallers_ContextCancellation(t *testing.T) {
+	// テスト用のGoファイルを作成
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.go")
+	err := os.WriteFile(testFile, []byte(`package test
+
+func TestFunction() {
+	targetFunc()
+}
+
+func targetFunc() {
+	// target function
+}
+`), 0644)
+	require.NoError(t, err, "テストファイル作成に失敗")
+
+	// モジュールマップの作成
+	modules := gomod.NewModuleMap(map[string]gomod.Module{
+		"test": {
+			Path: "test",
+			Root: tmpDir,
+		},
+	})
+
+	files := []string{testFile}
+
+	// 即時キャンセル用のコンテキストを作成
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // 直ちにキャンセル
+
+	// ExtractCallers を実行（キャンセルされたコンテキストで）
+	_, err = ExtractCallers(ctx, "test.targetFunc", files, *modules)
+
+	// キャンセルエラーが返されることを確認
+	assert.True(t, errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled),
+		"context.DeadlineExceeded または context.Canceled が期待されますが、実際: %v", err)
+}
+
+func TestExtractCallers_NormalOperation(t *testing.T) {
+	// 正常なケースのテスト
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.go")
+	require.NoError(t, os.WriteFile(testFile, []byte(`package test
+
+func TestFunction() {
+	targetFunc()
+}
+
+func targetFunc() {
+	// target function
+}
+`), 0644))
+
+	modules := gomod.NewModuleMap(map[string]gomod.Module{
+		"test": {
+			Path: "test",
+			Root: tmpDir,
+		},
+	})
+
+	files := []string{testFile}
+	ctx := context.Background()
+
+	callers, err := ExtractCallers(ctx, "test.targetFunc", files, *modules)
+	assert.NoError(t, err, "予期しないエラー")
+
+	// targetFunc を呼び出しているのは TestFunction なので、呼び出し元が1つ見つかるはず
+	assert.Len(t, callers, 1, "呼び出し元が見つかりませんでした")
+}

--- a/internal/callgraph/callgraph_test.go
+++ b/internal/callgraph/callgraph_test.go
@@ -1,0 +1,77 @@
+package callgraph_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/meian/rev-callgraph/internal/callgraph"
+	"github.com/meian/rev-callgraph/internal/gomod"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCallersTree_ContextCancellation(t *testing.T) {
+	ctx := context.Background()
+	testMod, modules, err := scanTestModules(ctx)
+	require.NoError(t, err)
+
+	// キャンセルされたコンテキストを作成
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// CallersTree を実行（キャンセルされたコンテキストで）
+	target := "github.com/meian/rev-callgraph/testdata/app.main"
+	_, err = callgraph.CallersTree(cancelCtx, *testMod, target, *modules, 0, nil, 0)
+
+	// キャンセルエラーが返されることを確認
+	assert.True(t, errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled),
+		"context.DeadlineExceeded または context.Canceled が期待されますが、実際: %v", err)
+}
+
+func TestCallersTree_CycleDetection(t *testing.T) {
+	ctx := context.Background()
+	testMod, modules, err := scanTestModules(ctx)
+	require.NoError(t, err)
+
+	// サイクル検出のテスト（既にseenマップに含まれている場合）
+	seen := map[string]struct{}{
+		"github.com/meian/rev-callgraph/testdata/app.main": {},
+	}
+
+	result, err := callgraph.CallersTree(ctx, *testMod, "github.com/meian/rev-callgraph/testdata/app.main", *modules, 0, seen, 0)
+	assert.NoError(t, err, "予期しないエラー")
+	require.NotNil(t, result, "結果が nil です")
+	assert.True(t, result.Cycled, "サイクル検出が期待されましたが、Cycled フラグが false です")
+}
+
+func TestCallersTree_MaxDepth(t *testing.T) {
+	ctx := context.Background()
+	testMod, modules, err := scanTestModules(ctx)
+	require.NoError(t, err)
+
+	// 最大深度のテスト（depth >= maxDepth の場合）
+	result, err := callgraph.CallersTree(ctx, *testMod, "github.com/meian/rev-callgraph/testdata/app.main", *modules, 1, nil, 1)
+	assert.NoError(t, err, "予期しないエラー")
+	require.NotNil(t, result, "結果が nil です")
+	// 最大深度に到達した場合、callersは空になることを確認
+	assert.Empty(t, result.Callers, "最大深度に到達した場合、callersは空であることが期待されます")
+}
+
+// scanTestModules は testdata 配下の モジュールをスキャンし、テスト用の app モジュールとModuleMapを返す
+func scanTestModules(ctx context.Context) (*gomod.Module, *gomod.ModuleMap, error) {
+	testdataPath := filepath.Join("..", "..", "testdata")
+	modPath := "github.com/meian/rev-callgraph/testdata/app"
+	modules, err := gomod.Scan(ctx, testdataPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, mod := range modules.Iter {
+		if mod.Path == modPath {
+			return &mod, modules, nil
+		}
+	}
+	return nil, modules, fmt.Errorf("%s モジュールが見つかりません", modPath)
+}

--- a/internal/contextutil/contextutil.go
+++ b/internal/contextutil/contextutil.go
@@ -1,0 +1,12 @@
+package contextutil
+
+import (
+	"context"
+	"errors"
+)
+
+// IsCanceledOrTimedOut は ctx がキャンセルまたはタイムアウトされていれば true を返します
+func IsCanceledOrTimedOut(ctx context.Context) bool {
+	err := ctx.Err()
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}

--- a/internal/contextutil/contextutil_test.go
+++ b/internal/contextutil/contextutil_test.go
@@ -1,0 +1,37 @@
+package contextutil_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/meian/rev-callgraph/internal/contextutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsCanceledOrTimedOut(t *testing.T) {
+	t.Run("not done", func(t *testing.T) {
+		ctx := context.Background()
+		assert.False(t, contextutil.IsCanceledOrTimedOut(ctx), "キャンセルまたはタイムアウトされた")
+	})
+
+	t.Run("canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		assert.True(t, contextutil.IsCanceledOrTimedOut(ctx), "キャンセルされていない")
+	})
+
+	t.Run("deadline exceeded", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+		defer cancel()
+		assert.Eventually(t, func() bool {
+			return contextutil.IsCanceledOrTimedOut(ctx)
+		}, 5*time.Second, time.Millisecond, "タイムアウトしなかった")
+	})
+
+	t.Run("deadline not exceeded", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		assert.False(t, contextutil.IsCanceledOrTimedOut(ctx), "キャンセルまたはタイムアウトされた")
+	})
+}

--- a/internal/gomod/scan.go
+++ b/internal/gomod/scan.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/meian/rev-callgraph/internal/contextutil"
 	"github.com/meian/rev-callgraph/internal/progress"
 	"golang.org/x/mod/modfile"
 )
@@ -16,6 +17,9 @@ func Scan(ctx context.Context, root string) (*ModuleMap, error) {
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
+		}
+		if contextutil.IsCanceledOrTimedOut(ctx) {
+			return ctx.Err()
 		}
 		if d.IsDir() || d.Name() != "go.mod" {
 			return nil

--- a/internal/gomod/scan_test.go
+++ b/internal/gomod/scan_test.go
@@ -1,0 +1,37 @@
+package gomod_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/meian/rev-callgraph/internal/gomod"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScan_ContextCancellation(t *testing.T) {
+	// テストデータのパスを取得
+	testdataPath := filepath.Join("..", "..", "testdata")
+
+	// 即時キャンセル用のコンテキストを作成
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // 直ちにキャンセル
+
+	// Scan を実行（キャンセルされたコンテキストで）
+	_, err := gomod.Scan(ctx, testdataPath)
+
+	// キャンセルエラーが返されることを確認
+	assert.True(t, errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled),
+		"context.DeadlineExceeded または context.Canceled が期待されますが、実際: %v", err)
+}
+
+func TestScan_NormalOperation(t *testing.T) {
+	// 正常なコンテキストでテスト
+	ctx := context.Background()
+	testdataPath := filepath.Join("..", "..", "testdata")
+
+	modules, err := gomod.Scan(ctx, testdataPath)
+	assert.NoError(t, err, "予期しないエラー")
+	assert.NotNil(t, modules, "modules が nil です")
+}

--- a/internal/grep/grep.go
+++ b/internal/grep/grep.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/meian/rev-callgraph/internal/contextutil"
 	"github.com/meian/rev-callgraph/internal/progress"
 )
 
@@ -35,6 +36,10 @@ func SearchFiles(ctx context.Context, root, target string) ([]string, error) {
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
+		}
+		// コンテキストキャンセルチェック
+		if contextutil.IsCanceledOrTimedOut(ctx) {
+			return ctx.Err()
 		}
 		// ディレクトリのスキップ
 		if d.IsDir() {

--- a/internal/grep/grep_test.go
+++ b/internal/grep/grep_test.go
@@ -2,14 +2,43 @@ package grep_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/meian/rev-callgraph/internal/grep"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSearchFiles(t *testing.T) {
+	root := t.TempDir()
+	// ライブラリ用フォルダ
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "pkg"), 0755))
+	// マッチするファイル
+	file1 := filepath.Join(root, "pkg", "a.go")
+	require.NoError(t, os.WriteFile(file1, []byte(`package pkg
+// call targetFunc()`), 0644))
+	// マッチしないファイル
+	file2 := filepath.Join(root, "pkg", "b.go")
+	require.NoError(t, os.WriteFile(file2, []byte(`package pkg
+func foo() {}`), 0644))
+	// vendor 配下のファイル（マッチしても候補外）
+	vendorDir := filepath.Join(root, "vendor", "pkg")
+	require.NoError(t, os.MkdirAll(vendorDir, 0755))
+	file3 := filepath.Join(vendorDir, "c.go")
+	require.NoError(t, os.WriteFile(file3, []byte(`package pkg
+// call targetFunc()`), 0644))
+
+	files, err := grep.SearchFiles(context.Background(), root, "targetFunc")
+	require.NoError(t, err, "SearchFiles error")
+	// file1 のみが返るべき
+	expected := []string{file1}
+	assert.ElementsMatch(t, files, expected, "SearchFiles returned unexpected files")
+}
+
+func TestSearchFiles_ContextCancellation(t *testing.T) {
 	root := t.TempDir()
 	// ライブラリ用フォルダ
 	os.MkdirAll(filepath.Join(root, "pkg"), 0755)
@@ -17,32 +46,16 @@ func TestSearchFiles(t *testing.T) {
 	file1 := filepath.Join(root, "pkg", "a.go")
 	os.WriteFile(file1, []byte(`package pkg
 // call targetFunc()`), 0644)
-	// マッチしないファイル
-	file2 := filepath.Join(root, "pkg", "b.go")
-	os.WriteFile(file2, []byte(`package pkg
-func foo() {}`), 0644)
-	// vendor 配下のファイル（マッチしても候補外）
-	vendorDir := filepath.Join(root, "vendor", "pkg")
-	os.MkdirAll(vendorDir, 0755)
-	file3 := filepath.Join(vendorDir, "c.go")
-	os.WriteFile(file3, []byte(`package pkg
-// call targetFunc()`), 0644)
 
-	files, err := grep.SearchFiles(context.Background(), root, "targetFunc")
-	if err != nil {
-		t.Fatalf("SearchFiles error: %v", err)
-	}
-	// file1 のみが返るべき
-	expected := map[string]bool{file1: true}
-	for _, f := range files {
-		if !expected[f] {
-			t.Errorf("unexpected file: %s", f)
-		}
-		expected[f] = false
-	}
-	for f, rem := range expected {
-		if rem {
-			t.Errorf("missing expected file: %s", f)
-		}
-	}
+	// 即時キャンセル用のコンテキストを作成
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // 直ちにキャンセル
+
+	// SearchFiles を実行（キャンセルされたコンテキストで）
+	_, err := grep.SearchFiles(ctx, root, "targetFunc")
+
+	// キャンセルエラーが返されることを確認
+	require.Error(t, err, "キャンセルエラーが期待されます")
+	assert.True(t, errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled),
+		"context.DeadlineExceeded または context.Canceled が期待されますが、実際: %v", err)
 }

--- a/internal/progress/context.go
+++ b/internal/progress/context.go
@@ -1,6 +1,8 @@
 package progress
 
-import "context"
+import (
+	"context"
+)
 
 type messengerKey struct{}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 各種処理（ファイル検索、モジュールスキャン、コールグラフ解析、呼び出し元抽出など）でコンテキストのキャンセルやタイムアウトに対応し、処理の早期終了が可能になりました。
  - コンテキストの状態を判定するユーティリティ関数を追加しました。

- **テスト**
  - コンテキストキャンセルやタイムアウト時の動作を確認するためのユニットテストを複数追加しました。
  - 既存テストを `testify` ライブラリを用いたアサーションに統一し、テストの可読性と一貫性を向上しました。
  - 新規ユーティリティ関数の動作検証テストを追加しました。

- **チョア**
  - 新しい依存パッケージを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->